### PR TITLE
Fix build for kernel 4.15

### DIFF
--- a/examples/mini/mini.c
+++ b/examples/mini/mini.c
@@ -307,7 +307,11 @@ void read_voe(void)
 
 /*****************************************************************************/
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
 void cyclic_task(unsigned long data)
+#else
+void cyclic_task(struct timer_list *data)
+#endif
 {
     // receive process data
     down(&master_sem);
@@ -492,8 +496,12 @@ int __init init_mini_module(void)
 #endif
 
     printk(KERN_INFO PFX "Starting cyclic sample thread.\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
     init_timer(&timer);
     timer.function = cyclic_task;
+#else
+    timer_setup(&timer, cyclic_task, 0);
+#endif
     timer.expires = jiffies + 10;
     add_timer(&timer);
 

--- a/sncn_installer/install.sh
+++ b/sncn_installer/install.sh
@@ -57,7 +57,7 @@ do_setup_interfaces () {
     else
       # Takes the first interface randomly if not
       interfaces=$(ifconfig | grep -e "^e[tn][a-z0-9]*" -o)
-      iface=$(${interfaces} | cut -d " " -f1)
+      iface=$(echo ${interfaces} | cut -d " " -f1)
       MAC=$(cat /sys/class/net/${iface}/address)
     fi
   fi


### PR DESCRIPTION
This fix doesn't automate the kernel modules signing. During the installation the following error will occur:
```
  INSTALL /Etherlab_EtherCAT_Master/devices/ec_generic.ko
At main.c:160:
- SSL error:02001002:system library:fopen:No such file or directory: ../crypto/bio/bss_file.c:74
- SSL error:2006D080:BIO routines:BIO_new_file:no such file: ../crypto/bio/bss_file.c:81
sign-file: certs/signing_key.pem: No such file or directory
  INSTALL /Etherlab_EtherCAT_Master/examples/mini/ec_mini.ko
```
This error seams doesn't affect the functionality and all components are being installed.

Update: I realized this error happens in earlier kernels as well, e.g., has been observed in 4.9 