### PR TITLE
disable cycles for arm architecture

### DIFF
--- a/sncn_installer/install.sh
+++ b/sncn_installer/install.sh
@@ -11,7 +11,8 @@ WORK_DIR="${SCRIPT_DIR}/.."
 ETHERCAT_SYSCONFIG="/etc/sysconfig/ethercat"
 ETHERCAT_INSTALL_PREFIX=""
 ETHERCAT_START_PREFIX="/opt/etherlab"
-CONFIGURE_FLAGS="--enable-sii-assign --disable-8139too --enable-hrtimer --enable-cycles"
+ARCH_FLAG=$(if [[ $(arch) != "a"* ]]; then echo "--enable-cycles" ; fi) #check for arm architecture
+CONFIGURE_FLAGS="--enable-sii-assign --disable-8139too --enable-hrtimer ${ARCH_FLAG}"
 
 do_configure() {
   cd ${WORK_DIR}


### PR DESCRIPTION
time stamp counters as implemented in tsc.h and tsc.c kernel functions are missing in ARM, so the configuration flag `--enable-cycles` is removed when compiling for ARM architecture