### PR TITLE
Fix simultaneous access externally and internally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,13 @@ syntax: glob
 **.mod.c
 **.o
 **.o.cmd
+**.o.d
 **.swp
 **/.deps/*.Po
 **/.tmp_*.gcno
 **~
 .tmp_versions
+.tags
 ChangeLog
 Doxyfile
 Kbuild
@@ -133,6 +135,7 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+master/gitlog.h
 modules.order
 script/Makefile
 script/Makefile.in

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash          
+echo -n "char* gitlog = \"" > master/gitlog.h && \
+	git log | head -1 | awk '{printf "%s", substr($2,1,8)}' >> master/gitlog.h && \
+	echo "\";" >> master/gitlog.h
 ./bootstrap
 ./configure --enable-sii-assign --disable-8139too --enable-hrtimer --enable-cycles
 sudo /opt/etherlab/etc/init.d/ethercat stop

--- a/master/fsm_coe.c
+++ b/master/fsm_coe.c
@@ -266,6 +266,16 @@ int ec_fsm_coe_success(
     return fsm->state == ec_fsm_coe_end;
 }
 
+/** Returns, if the state machine has terminated.
+ * \return non-zero if in end or error state.
+ */
+int ec_fsm_coe_ready(
+        const ec_fsm_coe_t *fsm /**< Finite state machine */
+        )
+{
+    return fsm->state == ec_fsm_coe_end || fsm->state == ec_fsm_coe_error;
+}
+
 /*****************************************************************************/
 
 /** Check if the received data are a CoE emergency request.
@@ -1166,6 +1176,11 @@ void ec_fsm_coe_dict_entry_response(
         }
 
         return;
+#ifdef DEBUG_SDO
+    } else {
+        EC_SLAVE_DBG(slave, 1, "Finished index 0x%04x, with subindex 0x%02x\n",
+            fsm->sdo->index, fsm->subindex);
+#endif
     }
 
     // another SDO description to fetch?
@@ -1179,6 +1194,11 @@ void ec_fsm_coe_dict_entry_response(
         }
 
         return;
+#ifdef DEBUG_SDO
+    } else {
+        EC_SLAVE_DBG(slave, 1, "Finished SDO dictionaries at index 0x%04x, and subindex 0x%02x\n",
+            fsm->sdo->index, fsm->subindex);
+#endif
     }
 
     fsm->state = ec_fsm_coe_end;

--- a/master/fsm_coe.h
+++ b/master/fsm_coe.h
@@ -76,6 +76,7 @@ void ec_fsm_coe_transfer(ec_fsm_coe_t *, ec_slave_t *, ec_sdo_request_t *);
 
 int ec_fsm_coe_exec(ec_fsm_coe_t *, ec_datagram_t *);
 int ec_fsm_coe_success(const ec_fsm_coe_t *);
+int ec_fsm_coe_ready(const ec_fsm_coe_t *);
 
 /*****************************************************************************/
 

--- a/master/fsm_master.c
+++ b/master/fsm_master.c
@@ -1477,6 +1477,7 @@ void ec_fsm_master_state_sdo_dictionary(
     }
 
     if (!ec_fsm_coe_success(&fsm->fsm_coe)) {
+        EC_SLAVE_ERR(slave, "ec_fsm_coe_success returned failure.\n");
         ec_fsm_master_restart(fsm);
         return;
     }

--- a/master/globals.h
+++ b/master/globals.h
@@ -60,7 +60,7 @@
 
 /** Seconds to wait before fetching SDO dictionary
     after slave entered PREOP state. */
-#define EC_WAIT_SDO_DICT 3
+#define EC_WAIT_SDO_DICT 0
 
 /** Minimum size of a buffer used with ec_state_string(). */
 #define EC_STATE_STRING_SIZE 32

--- a/master/module.c
+++ b/master/module.c
@@ -40,6 +40,7 @@
 #include "globals.h"
 #include "master.h"
 #include "device.h"
+#include "gitlog.h"
 
 /*****************************************************************************/
 
@@ -83,7 +84,7 @@ module_param_array(main_devices, charp, &master_count, S_IRUGO);
 MODULE_PARM_DESC(main_devices, "MAC addresses of main devices");
 module_param_array(backup_devices, charp, &backup_count, S_IRUGO);
 MODULE_PARM_DESC(backup_devices, "MAC addresses of backup devices");
-module_param_named(debug_level, debug_level, uint, S_IRUGO);
+module_param_named(debug_level, debug_level, uint, S_IRUGO+S_IWUSR);
 MODULE_PARM_DESC(debug_level, "Debug level");
 
 /** \endcond */
@@ -100,6 +101,7 @@ int __init ec_init_module(void)
     int i, ret = 0;
 
     EC_INFO("Master driver %s\n", EC_MASTER_VERSION);
+    EC_INFO("git commit %s\n", gitlog);
 
     sema_init(&master_sem, 1);
 

--- a/master/slave.c
+++ b/master/slave.c
@@ -155,6 +155,9 @@ void ec_slave_init(
 
     slave->sdo_dictionary_fetched = 0;
     slave->jiffies_preop = 0;
+#ifdef DEBUG_SDO
+    slave->retries = 0;
+#endif
 
     INIT_LIST_HEAD(&slave->sdo_requests);
     INIT_LIST_HEAD(&slave->reg_requests);

--- a/master/slave.h
+++ b/master/slave.h
@@ -255,6 +255,9 @@ struct ec_slave
     struct list_head eoe_requests; /**< EoE set IP parameter requests. */
 
     ec_fsm_slave_t fsm; /**< Slave state machine. */
+#ifdef DEBUG_SDO
+    uint32_t retries;
+#endif
 };
 
 /*****************************************************************************/


### PR DESCRIPTION
When the internal SDO request for the dictionary is interrupted by external applications downloading SDOs to the slave, bad things happen to the state machine. This Pull Request adds a test for the fsm_coe running before initiating an external SDO request. 

(This Pull Request also logs the latest git commit for tracking pre-release versions)  