### PR TITLE
Documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,159 @@
+# Changelog
+All notable changes to this project made by SYNAPTICON will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+##[Unreleased]
+### EtherCAT wrapper library
+#### Added
+- Enable reading/writing of string SDO values
+- Enable handling 64-bit integer values and setting the time of day
+- Check if the SDO request pointers are valid on upload/download
+- Add a function for bus rescanning
+- Add a function for preemptive bus rescanning
+- Enable preemptive slave vendor ID and product code fetching
+- Add a Synapticon changelog
+
+#### Fixed
+- Always null-terminate the string SDO values
+- Fix the domain registration during master initialization
+- Free the master domain in the proper place, when stopping the master
+- Fix segmentation fault on ecw_master_stop
+
+### EtherCAT library
+#### Added
+- Add a function to trigger bus rescanning
+
+#### Fixed
+- Suport Linux kernel 4.15.7
+- Fix: sncn_installer uses right sysconfig
+
+## [1.5.2-sncn-6] - 2018-10-23
+### EtherCAT wrapper library (v0.6)
+#### Added
+- Add version for libethercat_wrapper to distribution
+- Use syslog for logging
+- Add the object name to the SDO structure
+- Enable fetching some slave information before EtherCAT master init
+- Enable the wrapper to update slave states (ecw_master_scan)
+- Define code errors
+
+#### Changed
+- Change order of PDOs in domain reg - input, then output
+- General refactor
+- Improve slave clean up
+- Define the SDO entry type as an enum
+- Process SDOs according to their entry type on direct upload
+
+#### Removed
+- Remove the master info pointer from the wrapper master struct
+- Remove the unused and redundant alias variable from the slave struct
+
+#### Fixed
+- Always refresh the number of responding slaves
+- Fix the slave ID check
+- Fix SDO read/write while in OP state
+- Fix getting/setting of the slave state - add BOOT state
+- Fix: Return NULL if the SDO is not found
+- Various test fixes
+- Fix boolean SDO read/write
+- Fix the usage of slave aliases
+
+### EtherCAT library
+#### Added
+- Add custom install script
+- Support 4.13 and 4.15 kernels
+- Add gitlog tracking to startup kernel logging
+
+#### Changed
+- Disable 8139too by default
+- Reduce waiting period for SDOs
+
+#### Fixed
+- Fix for vm_fault struct change in 4.10 kernel
+- Fix for overlapping state machine operations
+- Fix single retries variable when multiple slaves exist
+
+## [1.5.2-sncn-5] - 2017-04-20
+### EtherCAT wrapper library (v0.5)
+#### Added
+- Add setting of slave operational state
+- Add usage of AL state enum for state request
+
+#### Changed
+- Improve AL state handling
+
+#### Removed
+- Remove initial upload of entry values
+
+#### Fixed
+- Fix domain registration issues
+- Fix byte alignement handling for PDOs
+- Fix master start and stop
+- Fix setup of SDO requests
+- Fix type warnings for PDO mappings
+
+### EtherCAT library
+#### Changed
+- Improve AL state handling
+
+## [1.5.2-sncn-4] - 2017-02-14
+### EtherCAT wrapper library
+#### Added
+- Add and integrate into build process
+
+### EtherCAT library
+#### Added
+- Add object code to SDO information object
+
+### EtherCAT drivers
+#### Fixed
+- Fix e1000e update script
+
+## [1.5.2-sncn-3] - 2016-12-16
+### EtherCAT wrapper library
+#### Added
+- Add SDO Info access to libethercat
+
+### Infrastructure
+#### Fixed
+- Fix interface name parsing
+
+## [1.5.2-sncn-2] - 2016-11-15
+### EtherCAT library
+#### Changed
+- Add BOOT state to exception (only FoE allowed)
+
+#### Fixed
+- Fix interface detection in installer script
+- Fixed fragmented SoE write request
+- Prevent CCAT auto-loading
+
+## [1.5.2-sncn-1] - 2016-05-04
+### EtherCAT library
+#### Added
+- Add additional README on how to build a release
+- Add construction of Synapticon EtherCAT master installer
+- Add ccat driver 0.14
+- Add 3.18 driver for EtherCAT
+
+#### Changed
+- Change version gathering from 'hg id' to 'git describe'
+- Increased timeout value to be able to initialize AX5206
+
+#### Removed
+- Remove e1000e driver from configuration
+
+#### Fixed
+- Updated the driver to cope with NVM checksum problem
+- Fix TIMED UNMATCH warning
+- Fix compilation on kernels > 4.2.0
+- Fix FoE timeout calculation bug
+
+[Unreleased]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-6...HEAD
+[1.5.2-sncn-6]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-5...v1.5.2-sncn-6
+[1.5.2-sncn-5]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-4...v1.5.2-sncn-5
+[1.5.2-sncn-4]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-3...v1.5.2-sncn-4
+[1.5.2-sncn-3]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-2...v1.5.2-sncn-3
+[1.5.2-sncn-2]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-1...v1.5.2-sncn-2
+[1.5.2-sncn-1]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/796d3f112f485ad20b5ed67a8f0ef02111227ef3...v1.5.2-sncn-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,6 @@ All notable changes to this project made by SYNAPTICON will be documented in thi
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ##[Unreleased]
-### EtherCAT wrapper library
-#### Added
-- Enable reading/writing of string SDO values
-- Enable handling 64-bit integer values and setting the time of day
-- Check if the SDO request pointers are valid on upload/download
-- Add a function for bus rescanning
-- Add a function for preemptive bus rescanning
-- Enable preemptive slave vendor ID and product code fetching
-- Add a Synapticon changelog
-
-#### Fixed
-- Always null-terminate the string SDO values
-- Fix the domain registration during master initialization
-- Free the master domain in the proper place, when stopping the master
-- Fix segmentation fault on ecw_master_stop
-
-### EtherCAT library
 #### Added
 - Add a function to trigger bus rescanning
 
@@ -29,37 +12,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix: sncn_installer uses right sysconfig
 
 ## [1.5.2-sncn-6] - 2018-10-23
-### EtherCAT wrapper library (v0.6)
-#### Added
-- Add version for libethercat_wrapper to distribution
-- Use syslog for logging
-- Add the object name to the SDO structure
-- Enable fetching some slave information before EtherCAT master init
-- Enable the wrapper to update slave states (ecw_master_scan)
-- Define code errors
-
-#### Changed
-- Change order of PDOs in domain reg - input, then output
-- General refactor
-- Improve slave clean up
-- Define the SDO entry type as an enum
-- Process SDOs according to their entry type on direct upload
-
-#### Removed
-- Remove the master info pointer from the wrapper master struct
-- Remove the unused and redundant alias variable from the slave struct
-
-#### Fixed
-- Always refresh the number of responding slaves
-- Fix the slave ID check
-- Fix SDO read/write while in OP state
-- Fix getting/setting of the slave state - add BOOT state
-- Fix: Return NULL if the SDO is not found
-- Various test fixes
-- Fix boolean SDO read/write
-- Fix the usage of slave aliases
-
-### EtherCAT library
 #### Added
 - Add custom install script
 - Support 4.13 and 4.15 kernels
@@ -75,52 +27,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix single retries variable when multiple slaves exist
 
 ## [1.5.2-sncn-5] - 2017-04-20
-### EtherCAT wrapper library (v0.5)
-#### Added
-- Add setting of slave operational state
-- Add usage of AL state enum for state request
-
-#### Changed
-- Improve AL state handling
-
-#### Removed
-- Remove initial upload of entry values
-
-#### Fixed
-- Fix domain registration issues
-- Fix byte alignement handling for PDOs
-- Fix master start and stop
-- Fix setup of SDO requests
-- Fix type warnings for PDO mappings
-
-### EtherCAT library
 #### Changed
 - Improve AL state handling
 
 ## [1.5.2-sncn-4] - 2017-02-14
-### EtherCAT wrapper library
-#### Added
-- Add and integrate into build process
-
-### EtherCAT library
 #### Added
 - Add object code to SDO information object
 
-### EtherCAT drivers
 #### Fixed
 - Fix e1000e update script
 
 ## [1.5.2-sncn-3] - 2016-12-16
-### EtherCAT wrapper library
-#### Added
-- Add SDO Info access to libethercat
-
-### Infrastructure
 #### Fixed
 - Fix interface name parsing
 
 ## [1.5.2-sncn-2] - 2016-11-15
-### EtherCAT library
 #### Changed
 - Add BOOT state to exception (only FoE allowed)
 
@@ -130,7 +51,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Prevent CCAT auto-loading
 
 ## [1.5.2-sncn-1] - 2016-05-04
-### EtherCAT library
 #### Added
 - Add additional README on how to build a release
 - Add construction of Synapticon EtherCAT master installer

--- a/INSTALL
+++ b/INSTALL
@@ -15,7 +15,7 @@ Synapticon provides its own simplified installation script that enables the
 users to completely build and install the IgH EtherCAT master and all its
 dependencies using only one command on Debian based systems (incl. Ubuntu):
 
-$ sncn_installer/install.sh eth0
+$ sudo sncn_installer/install.sh eth0
 
 ... where the "eth0" is the network adapter that will be used for EtherCAT.
 

--- a/INSTALL
+++ b/INSTALL
@@ -8,8 +8,21 @@ vim: set spelllang=en spell tw=78
 
 -------------------------------------------------------------------------------
 
-Building and installing
-=======================
+Synapticon IgH EtherCAT master installation instructions
+========================================================
+
+Synapticon provides its own simplified installation script that enables the
+users to completely build and install the IgH EtherCAT master and all its
+dependencies using only one command on Debian based systems (incl. Ubuntu):
+
+$ sncn_installer/install.sh eth0
+
+... where the "eth0" is the network adapter that will be used for EtherCAT.
+
+-------------------------------------------------------------------------------
+
+Original IgH EtherCAT master building and installing instructions
+=================================================================
 
 The complete build and installation procedure is described in the respective
 section of the documentation available from http://etherlab.org/en/ethercat.

--- a/README
+++ b/README
@@ -15,6 +15,7 @@ Contents:
 4) Realtime & Tuning
 5) License
 6) Coding Style
+7) Synapticon-specific changes
 
 ------------------------------------------------------------------------------
 
@@ -103,5 +104,19 @@ property and similar rights of Beckhoff Automation GmbH.
 ===============
 
 Developers shall use the coding style rules in the CodingStyle.txt file.
+
+------------------------------------------------------------------------------
+
+7) Synapticon-specific changes
+==============================
+
+This version of the IgH EtherCAT master contains changes made by Synapticon in
+order to support its products.
+
+All of the changes made from the original IgH EtherCAT master will be listed in
+the CHANGELOG.md file.
+
+Apart from the changes made to the base of this product, Synapticon has also
+added some additional instructions, as well as installation and helper scripts.
 
 ------------------------------------------------------------------------------

--- a/libethercat_wrapper/CHANGELOG.md
+++ b/libethercat_wrapper/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ##[Unreleased]
 ### Added
+- Add version to the build process
 - Enable reading/writing of string SDO values
 - Enable handling 64-bit integer values and setting the time of day
 - Check if the SDO request pointers are valid on upload/download

--- a/libethercat_wrapper/CHANGELOG.md
+++ b/libethercat_wrapper/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+All notable changes to this project made by SYNAPTICON will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+##[Unreleased]
+### Added
+- Enable reading/writing of string SDO values
+- Enable handling 64-bit integer values and setting the time of day
+- Check if the SDO request pointers are valid on upload/download
+- Add a function for bus rescanning
+- Add a function for preemptive bus rescanning
+- Enable preemptive slave vendor ID and product code fetching
+- Add a Synapticon changelog
+
+### Fixed
+- Always null-terminate the string SDO values
+- Fix the domain registration during master initialization
+- Free the master domain in the proper place, when stopping the master
+- Fix segmentation fault on ecw_master_stop
+
+## [1.5.2-sncn-6] - 2018-10-23
+### Added
+- Use syslog for logging
+- Add the object name to the SDO structure
+- Enable fetching some slave information before EtherCAT master init
+- Allow an update of the slave states (ecw_master_scan)
+- Define code errors
+
+### Changed
+- Change order of PDOs in domain reg - input, then output
+- General refactor
+- Improve slave clean up
+- Define the SDO entry type as an enum
+- Process SDOs according to their entry type on direct upload
+
+### Removed
+- Remove the master info pointer from the master struct
+- Remove the unused and redundant alias variable from the slave struct
+
+### Fixed
+- Always refresh the number of responding slaves
+- Fix the slave ID check
+- Fix SDO read/write while in OP state
+- Fix getting/setting of the slave state - add BOOT state
+- Fix: Return NULL if the SDO is not found
+- Various test fixes
+- Fix boolean SDO read/write
+- Fix the usage of slave aliases
+
+## [1.5.2-sncn-5] - 2017-04-20
+### Added
+- Add setting of slave operational state
+- Add usage of AL state enum for state request
+
+### Changed
+- Improve AL state handling
+
+### Removed
+- Remove initial upload of entry values
+
+### Fixed
+- Fix domain registration issues
+- Fix byte alignement handling for PDOs
+- Fix master start and stop
+- Fix setup of SDO requests
+- Fix type warnings for PDO mappings
+
+## [1.5.2-sncn-4] - 2017-02-14
+### Added
+- Add and integrate into build process
+
+## [1.5.2-sncn-3] - 2016-12-16
+### Added
+- Add SDO Info access to libethercat
+
+[Unreleased]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-6...HEAD
+[1.5.2-sncn-6]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-5...v1.5.2-sncn-6
+[1.5.2-sncn-5]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-4...v1.5.2-sncn-5
+[1.5.2-sncn-4]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-3...v1.5.2-sncn-4
+[1.5.2-sncn-3]: https://github.com/synapticon/Etherlab_EtherCAT_Master/compare/v1.5.2-sncn-2...v1.5.2-sncn-3

--- a/sncn_installer/install.sh
+++ b/sncn_installer/install.sh
@@ -67,8 +67,8 @@ do_setup_interfaces () {
   echo "KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"${ETHERCAT_USER_GROUP}\"" | sudo tee --append ${UDEV_RULES_FILE}
 
   # Link the sysconfig EtherCAT file
-  if [[ -f "${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG}" ]]; then
-    sudo rm ${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG}
+  if [[ -f "${ETHERCAT_SYSCONFIG}" ]]; then
+    sudo rm ${ETHERCAT_SYSCONFIG}
   else
     sudo mkdir -p ${SYSCONFIG_DIR}
   fi

--- a/sncn_installer/install.sh
+++ b/sncn_installer/install.sh
@@ -66,9 +66,13 @@ do_setup_interfaces () {
   sudo rm -rf ${UDEV_RULES_FILE}
   echo "KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"${ETHERCAT_USER_GROUP}\"" | sudo tee --append ${UDEV_RULES_FILE}
 
-  # Copy the sysconfig EtherCAT file
-  sudo mkdir -p ${SYSCONFIG_DIR}
-  sudo cp ${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG} ${ETHERCAT_SYSCONFIG}
+  # Link the sysconfig EtherCAT file
+  if [[ -f "${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG}" ]]; then
+    sudo rm ${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG}
+  else
+    sudo mkdir -p ${SYSCONFIG_DIR}
+  fi
+  sudo ln -s ${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG} ${ETHERCAT_SYSCONFIG}
 
   # Add detected interfaces and delete old ones
   sudo sed -i '/MASTER[^0].*_DEVICE/d' ${ETHERCAT_SYSCONFIG}

--- a/sncn_installer/install.sh
+++ b/sncn_installer/install.sh
@@ -16,9 +16,9 @@ ETHERCAT_USER_GROUP="$(whoami)"
 UDEV_RULES_FILE="/etc/udev/rules.d/99-EtherCAT.rules"
 SCRIPT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 WORK_DIR="${SCRIPT_DIR}/.."
+SYSCONFIG_DIR="/etc/sysconfig/"
 ETHERCAT_SYSCONFIG="/etc/sysconfig/ethercat"
 ETHERCAT_INSTALL_PREFIX="/opt/etherlab"
-ETHERCAT_START_PREFIX="/opt/etherlab"
 CONFIGURE_FLAGS="--enable-sii-assign --disable-8139too --enable-hrtimer --enable-cycles"
 
 do_configure() {
@@ -31,10 +31,10 @@ do_configure() {
   ./bootstrap
   ./configure ${CONFIGURE_FLAGS} --prefix=${ETHERCAT_INSTALL_PREFIX}
 
-  if [[ -f "${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat" ]]; then
+  if [[ -f "/etc/init.d/ethercat" ]]; then
+    sudo /etc/init.d/ethercat stop
+  elif [[ -f "${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat" ]]; then
     sudo ${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat stop
-  elif [[ -f "${ETHERCAT_START_PREFIX}/etc/init.d/ethercat" ]]; then
-    sudo ${ETHERCAT_START_PREFIX}/etc/init.d/ethercat stop
   fi
 }
 
@@ -47,12 +47,28 @@ do_install () {
   sudo make modules_install install
   sudo ldconfig
   sudo depmod
+
+  # Link the service
+  if [[ -f "/etc/init.d/ethercat" ]]; then
+    sudo rm /etc/init.d/ethercat
+  fi
+  sudo ln -s ${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat /etc/init.d/ethercat
+
+  # Link the binary
+  if [[ -f "/usr/bin/ethercat" ]]; then
+    sudo rm /usr/bin/ethercat
+  fi
+  sudo ln -s ${ETHERCAT_INSTALL_PREFIX}/bin/ethercat /usr/bin/ethercat
 }
 
 do_setup_interfaces () {
   # Add udev rule
   sudo rm -rf ${UDEV_RULES_FILE}
   echo "KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"${ETHERCAT_USER_GROUP}\"" | sudo tee --append ${UDEV_RULES_FILE}
+
+  # Copy the sysconfig EtherCAT file
+  sudo mkdir -p ${SYSCONFIG_DIR}
+  sudo cp ${ETHERCAT_INSTALL_PREFIX}${ETHERCAT_SYSCONFIG} ${ETHERCAT_SYSCONFIG}
 
   # Add detected interfaces and delete old ones
   sudo sed -i '/MASTER[^0].*_DEVICE/d' ${ETHERCAT_SYSCONFIG}
@@ -79,10 +95,10 @@ do_setup_interfaces () {
 }
 
 do_start() {
-  if [[ -f "${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat" ]]; then
+  if [[ -f "/etc/init.d/ethercat" ]]; then
+    sudo /etc/init.d/ethercat start
+  elif [[ -f "${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat" ]]; then
     sudo ${ETHERCAT_INSTALL_PREFIX}/etc/init.d/ethercat start
-  elif [[ -f "${ETHERCAT_START_PREFIX}/etc/init.d/ethercat" ]]; then
-    sudo ${ETHERCAT_START_PREFIX}/etc/init.d/ethercat start
   fi
 }
 


### PR DESCRIPTION
1) Added a CHANGELOG.md file that covers all of the changes (by version) from the original IgH
2) Added Synapticon-specific stuff to the documentation (README and INSTALL)
3) Fixed the "sncn_installer/install.sh" (so that it completely installs the ECAT master onto a fresh Ubuntu system - tested)

I did not rename the "sncn_installer" directory because it is being used in several projects. Also, I tried to stay true to the original IgH installer, so that we don't have to change any of the original IgH instructions.

Once these changes are merged into develop, we will merge everything to master and create a new release (v1.5.2-sncn-7).

Any suggestions are welcome.